### PR TITLE
Change package name in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "x-editable",
+  "name": "select2-x-editable",
   "version": "1.5.1",
   "ignore": [
     "CHANGELOG.txt",


### PR DESCRIPTION
It is currently difficult to load this code using Bower package manager because package name `x-editable` is identical with the original package by Vitalets.

My proposal and the point of this PR is to change the package name to differentiate it from the original package. The new package should also be registered in Bower.io to make it available there.
